### PR TITLE
Allow user to decide on static or shared wxWidgets monolithic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,23 @@ cmake_minimum_required(VERSION 3.20)
 
 project(wxWidgets LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 17)
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if (NOT isMultiConfig)
+    message("\nBecause you are using a single target generator, you MUST specify")
+    message("    a \"--config [Debug|Release]\" option with the cmake --build command\n")
+
+    set(allowedBuildTypes Debug Release)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowedBuildTypes}")
+
+    if (NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+    elseif (NOT CMAKE_BUILD_TYPE IN_LIST allowedBuildTypes)
+        message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
+    endif()
+endif()
+
+set(CMAKE_CXX_STANDARD 17) # future-proofing, wxWidgets 3.3 requires C++11, 3.4 will require C++14, etc.
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -33,31 +49,15 @@ else()
     set(CMAKE_C_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C Release flags" FORCE)
 endif()
 
-get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-
-if (NOT isMultiConfig)
-    message("\nBecause you are using a single target generator, you MUST specify")
-    message("    a \"--config [Debug|Release]\" option with the cmake --build command\n")
-
-    set(allowedBuildTypes Debug Release)
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowedBuildTypes}")
-
-    if (NOT CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
-    elseif (NOT CMAKE_BUILD_TYPE IN_LIST allowedBuildTypes)
-        message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
-    endif()
-endif()
-
 include(src/wxWidgets.cmake) # This will set ${common_sources}, ${msw_sources}, ${unix_sources} and ${osx_sources}
 include(src/wxCLib.cmake)    # This will set ${wxCLib_sources} with list of files
 
 if (WIN32)
-    add_library(wxWidgets STATIC ${common_sources} ${msw_sources} )
+    add_library(wxWidgets ${common_sources} ${msw_sources})
 elseif (APPLE)
-    add_library(wxWidgets STATIC ${common_sources} ${osx_sources} )
+    add_library(wxWidgets ${common_sources} ${osx_sources} )
 elseif (UNIX)
-    add_library(wxWidgets STATIC ${common_sources} ${unix_sources} )
+    add_library(wxWidgets ${common_sources} ${unix_sources} )
 endif()
 
 add_library(wxCLib STATIC ${wxCLib_sources} )
@@ -72,6 +72,10 @@ if (WIN32)
         __WXMSW__
         WIN32
     )
+endif()
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(wxWidgets PRIVATE WXMAKINGDLL)
 endif()
 
 target_compile_definitions(wxWidgets PRIVATE
@@ -143,3 +147,9 @@ target_include_directories(wxCLib PRIVATE
     src/zlib
     src/expat/expat/lib
 )
+
+if (BUILD_SHARED_LIBS)
+    if (WIN32)
+        target_link_libraries(wxWidgets PRIVATE wxCLib Winmm Ws2_32 Rpcrt4 Comctl32)
+    endif()
+endif()


### PR DESCRIPTION
This PR removes the fixed library type from the wxWidgets monoloithic library, and instead allows it to be controlled via `BUILD_SHARED_LIBS`. The default is still a static library, but to change that the user would call:

```
    cmake -DBUILD_SHARED_LIBS=ON build
```
