### PR TITLE
Change target location/filenames, generate package configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 setup.h
 
+# This file gets generated from cmake/wxSnapshotConfig.cmake.in
+wxSnapshotConfig.cmake
+
 build/
 buildgtk/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,13 +70,18 @@ elseif(UNIX)
     set(CMAKE_C_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C Release flags" FORCE)
 endif()
 
+include(GNUInstallDirs)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
+
 include( wxWidgets.cmake )  # This will set ${common_sources}, ${msw_sources}, ${unix_sources} and ${osx_sources}
 include( wxCLib.cmake )     # This will set ${wxCLib_sources} with list of files
 
 if (WIN32)
     list(APPEND wxCLib_sources src/tiff/libtiff/tif_win32.c)
 endif()
-
 
 if (WIN32)
     add_library(wxWidgets33 ${common_sources} ${msw_sources} )
@@ -204,3 +209,15 @@ if (BUILD_SHARED_LIBS)
         target_link_libraries(wxWidgets33 PRIVATE wxCLib Winmm Ws2_32 Rpcrt4 Comctl32)
     endif()
 endif()
+
+# Specify the input template
+set(TEMPLATE_DIR ${CMAKE_SOURCE_DIR}/cmake)
+set(TEMPLATE_FILE ${TEMPLATE_DIR}/wxSnapshotConfig.cmake.in)
+
+# Create a Config.cmake file for the build tree
+include(CMakePackageConfigHelpers)
+configure_file(
+    ${TEMPLATE_FILE}
+    "${CMAKE_CURRENT_LIST_DIR}/wxSnapshotConfig.cmake"
+    @ONLY
+)

--- a/cmake/wxSnapshotConfig.cmake.in
+++ b/cmake/wxSnapshotConfig.cmake.in
@@ -1,0 +1,20 @@
+set(PACKAGE_VERSION "@PACKAGE_VERSION@")
+
+# Set the path to the include directory
+set(wxWidgets_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/include")
+set(wxWidgets_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+# Set the path/names of the libraries to link to
+set(wxWidgets_LIB_DIRS
+   "@CMAKE_BINARY_DIR@/lib" 
+)
+
+message(NOTICE "Setting CMAKE_DEBUG_POSTFIX to 'd' to match wxWidgets debug library filenames")
+set (CMAKE_DEBUG_POSTFIX d)
+
+# Set the names of the libraries to link to
+if(BUILD_SHARED_LIBS)
+    set(wxWidgets_LIBRARIES wxWidgets33${CMAKE_DEBUG_POSTFIX})
+else()
+    set(wxWidgets_LIBRARIES "wxWidgets33${CMAKE_DEBUG_POSTFIX} wxCLib${CMAKE_DEBUG_POSTFIX}")
+endif()


### PR DESCRIPTION
This PR changes where the libraries and possible dll are created, as well as the name of the libraries/dll in a Debug build. When CMake is configured, it creates a `wxSnapshotConfig.cmake` file in the root of the project that can be used by callers to get the include and library directories, as well as the library name(s).

With this change both Release and Debug dlls are created in build/lib (the Debug version is named `wxWidgets33d`).
