### PR TITLE
Change how library names are built and packaged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ include(GNUInstallDirs)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/lib>)
+set (CMAKE_DEBUG_POSTFIX d)
 
 include( wxWidgets.cmake )  # This will set ${common_sources}, ${msw_sources}, ${unix_sources} and ${osx_sources}
 include( wxCLib.cmake )     # This will set ${wxCLib_sources} with list of files

--- a/cmake/wxSnapshotConfig.cmake.in
+++ b/cmake/wxSnapshotConfig.cmake.in
@@ -6,15 +6,19 @@ set(wxWidgets_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 # Set the path/names of the libraries to link to
 set(wxWidgets_LIB_DIRS
-   "@CMAKE_BINARY_DIR@/lib" 
+   "@CMAKE_BINARY_DIR@/lib"
 )
-
-message(NOTICE "Setting CMAKE_DEBUG_POSTFIX to 'd' to match wxWidgets debug library filenames")
-set (CMAKE_DEBUG_POSTFIX d)
 
 # Set the names of the libraries to link to
 if(BUILD_SHARED_LIBS)
-    set(wxWidgets_LIBRARIES wxWidgets33${CMAKE_DEBUG_POSTFIX})
+    set(wxWidgets_LIBRARIES wxWidgets33)
 else()
-    set(wxWidgets_LIBRARIES "wxWidgets33${CMAKE_DEBUG_POSTFIX} wxCLib${CMAKE_DEBUG_POSTFIX}")
+    set(wxWidgets_LIBRARIES "wxWidgets33 wxCLib")
 endif()
+
+# Add 'd' as a suffix to the libraries in Debug builds
+foreach(item IN LISTS wxWidgets_LIBRARIES)
+    set(new_item "${item}$<$<CONFIG:Debug>:d>")
+    list(REMOVE_ITEM wxWidgets_LIBRARIES ${item})
+    list(APPEND wxWidgets_LIBRARIES ${new_item})
+endforeach()


### PR DESCRIPTION
This PR updates the previous PR by adding `set (CMAKE_DEBUG_POSTFIX d)` in CMakeLists.txt so that the Debug libraries will have a 'd' postfix. In `wxSnapShotConfig.cmake.in` I added a `foreach` loop to add the 'd' postfix when the package caller is creating a Debug build.